### PR TITLE
Support for generic subscriptions

### DIFF
--- a/src/main/In/HttpSubscriptionsClient.cs
+++ b/src/main/In/HttpSubscriptionsClient.cs
@@ -1,5 +1,5 @@
 ﻿using ei8.Cortex.Subscriptions.Common;
-using ei8.Cortex.Subscriptions.Common.Attributes;
+using ei8.Cortex.Subscriptions.Common.Extensions;
 using ei8.Cortex.Subscriptions.Common.Receivers;
 using neurUL.Common.Http;
 using NLog;
@@ -7,7 +7,6 @@ using Polly;
 using Polly.Retry;
 using Splat;
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,23 +36,10 @@ namespace ei8.Cortex.Subscriptions.Client.In
 
         private async Task AddSubscriptionInternal(string baseUrl, IAddSubscriptionReceiverRequest<T> request, CancellationToken token = default)
         {
-            var subscriptionPath = GetSubscriptionPath(request.ReceiverInfo);
+            var subscriptionPath = request.ReceiverInfo.GetSubscriptionPath();
             var requestUrl = $"{baseUrl}/subscriptions/receivers/{subscriptionPath}";
 
             await requestProvider.PostAsync(requestUrl, request);
-        }
-
-        private string GetSubscriptionPath(IReceiverInfo request)
-        {
-            var type = request.GetType();
-            var subscriptionPathAttribute = type.GetCustomAttributes(typeof(SubscriptionPathAttribute), false)
-                                                .FirstOrDefault() as SubscriptionPathAttribute;
-
-            if (subscriptionPathAttribute != null)
-                return subscriptionPathAttribute.EndpointPath;
-
-            else
-                throw new ArgumentException($"Unsupported receiver info type: {type.FullName}");
         }
     }
 }

--- a/src/main/In/HttpSubscriptionsClient.cs
+++ b/src/main/In/HttpSubscriptionsClient.cs
@@ -1,16 +1,19 @@
 ﻿using ei8.Cortex.Subscriptions.Common;
+using ei8.Cortex.Subscriptions.Common.Attributes;
+using ei8.Cortex.Subscriptions.Common.Receivers;
 using neurUL.Common.Http;
 using NLog;
 using Polly;
 using Polly.Retry;
 using Splat;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace ei8.Cortex.Subscriptions.Client.In
 {
-    public class HttpSubscriptionsClient : ISubscriptionsClient
+    public class HttpSubscriptionsClient<T> : ISubscriptionsClient<T> where T : IReceiverInfo
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -18,7 +21,7 @@ namespace ei8.Cortex.Subscriptions.Client.In
                                                                  .WaitAndRetryAsync(
                                                                     3,
                                                                     attempt => TimeSpan.FromMilliseconds(100 * Math.Pow(2, attempt)),
-                                                                    (ex, _) => HttpSubscriptionsClient.Logger.Error(ex, "Error occurred while communicating with ei8 Cortex Subscriptions. " + ex.InnerException?.Message)
+                                                                    (ex, _) => HttpSubscriptionsClient<T>.Logger.Error(ex, "Error occurred while communicating with ei8 Cortex Subscriptions. " + ex.InnerException?.Message)
                                                                  );
         private IRequestProvider requestProvider;
 
@@ -27,16 +30,30 @@ namespace ei8.Cortex.Subscriptions.Client.In
             this.requestProvider = requestProvider ?? Locator.Current.GetService<IRequestProvider>();
         }
 
-        public async Task AddSubscription(string baseUrl, BrowserSubscriptionInfo request, CancellationToken token = default)
+        public async Task AddSubscription(string baseUrl, IAddSubscriptionReceiverRequest<T> request, CancellationToken token = default)
         {
             await ExponentialRetry.ExecuteAsync(async () => await AddSubscriptionInternal(baseUrl, request, token).ConfigureAwait(false));
         }
 
-        private async Task AddSubscriptionInternal(string baseUrl, BrowserSubscriptionInfo request, CancellationToken token = default)
+        private async Task AddSubscriptionInternal(string baseUrl, IAddSubscriptionReceiverRequest<T> request, CancellationToken token = default)
         {
-            var requestUrl = $"{baseUrl}/subscriptions";
+            var subscriptionPath = GetSubscriptionPath(request.ReceiverInfo);
+            var requestUrl = $"{baseUrl}/subscriptions/receivers/{subscriptionPath}";
 
             await requestProvider.PostAsync(requestUrl, request);
+        }
+
+        private string GetSubscriptionPath(IReceiverInfo request)
+        {
+            var type = request.GetType();
+            var subscriptionPathAttribute = type.GetCustomAttributes(typeof(SubscriptionPathAttribute), false)
+                                                .FirstOrDefault() as SubscriptionPathAttribute;
+
+            if (subscriptionPathAttribute != null)
+                return subscriptionPathAttribute.EndpointPath;
+
+            else
+                throw new ArgumentException($"Unsupported receiver info type: {type.FullName}");
         }
     }
 }

--- a/src/main/In/ISubscriptionsClient.cs
+++ b/src/main/In/ISubscriptionsClient.cs
@@ -1,11 +1,12 @@
 ﻿using ei8.Cortex.Subscriptions.Common;
+using ei8.Cortex.Subscriptions.Common.Receivers;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace ei8.Cortex.Subscriptions.Client.In
 {
-    public interface ISubscriptionsClient
+    public interface ISubscriptionsClient<T> where T : IReceiverInfo
     {
-        Task AddSubscription(string baseUrl, BrowserSubscriptionInfo request, CancellationToken token = default);
+        Task AddSubscription(string baseUrl, IAddSubscriptionReceiverRequest<T> request, CancellationToken token = default);
     }
 }


### PR DESCRIPTION
* Separate subscription info from receiver info
* Make `In.ISubscriptionClient` generic, constrained with `Common.IReceiverInfo`